### PR TITLE
Fixing Authorization header in index.njk

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -72,7 +72,7 @@
     <code>
         <pre>{{ headers_string }}</pre>
     </code>
-    <h3>Authroization</h3>
+    <h3>Authorization</h3>
     <ul>
         <li>Authorization kind:
             <code>{{ auth_kind }}</code>


### PR DESCRIPTION
Updated the header "Authroization" to the correct spelling "Authorization" in index.njk